### PR TITLE
Use unsanitized name to determine whether zip entry is a dir

### DIFF
--- a/src/formats/zip.rs
+++ b/src/formats/zip.rs
@@ -42,7 +42,7 @@ impl Archive for ZipArchive {
         for idx in 0..self.rdr.len() {
             let file = self.rdr.by_index(idx)?;
             let name = file.sanitized_name();
-            if file.unix_mode().unwrap_or(0) & 16384 == 0 && !name.ends_with("/") {
+            if file.unix_mode().unwrap_or(0) & 16384 == 0 && !file.name().ends_with("/") {
                 helper.write_file_with_progress(name, file)?;
             } else {
                 let path = helper.path().join(name);


### PR DESCRIPTION
I tried to unpack a `jar` file, but it failed with `error: File exists (os error 17)`

After digging a bit deeper, I found that `unbox` treated `META-INF` directory in the `jar` file as a file and not a directory. The `sanitized_name` strips the trailing slash as well which fails the directory check. Therefore this PR uses unsanitized name to check whether the zip entry is a directory or not.