### PR TITLE
fix AR on windows

### DIFF
--- a/src/formats/ar.rs
+++ b/src/formats/ar.rs
@@ -43,7 +43,7 @@ impl Archive for ArArchive {
             let path = {
                 #[cfg(windows)]
                 {
-                    PathBuf::new(String::from_utf8(header.identifier())?)
+                    PathBuf::from(String::from_utf8(header.identifier().to_vec())?)
                 }
                 #[cfg(unix)]
                 {


### PR DESCRIPTION
Hi @mitsuhiko,

The code currently doesn't build on windows on latest stable rust.
I'm not sure on what version it last compiled, since `PathBuf::new()` doesn't accept any parameters.

Also, `String::from_utf8` expected a `Vec`.

It compiles and works fine with this change.

Thanks for this lovely tool :)